### PR TITLE
Port to the Alcotest 1.0+ API

### DIFF
--- a/src/lib_error_monad/test/test_error_tables.ml
+++ b/src/lib_error_monad/test/test_error_tables.ml
@@ -185,4 +185,5 @@ let tests =
     Alcotest_lwt.test_case "self_clean" `Quick test_length;
     Alcotest_lwt.test_case "order" `Quick test_order ]
 
-let () = Alcotest.run "error_tables" [("error_tables", tests)]
+let () =
+  Alcotest_lwt.run "error_tables" [("error_tables", tests)] |> Lwt_main.run

--- a/src/lib_micheline/test/test_parser.ml
+++ b/src/lib_micheline/test/test_parser.ml
@@ -687,7 +687,8 @@ let wrap (n, f) =
       >>= function Ok () -> Lwt.return_unit | Error err -> Lwt.fail_with err)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-lib-micheline"
     [("micheline", List.map wrap tests)]
+  |> Lwt_main.run

--- a/src/lib_p2p/test/test_p2p_banned_peers.ml
+++ b/src/lib_p2p/test/test_p2p_banned_peers.ml
@@ -82,10 +82,11 @@ let () =
     Alcotest_lwt.test_case n `Quick (fun _ () ->
         Lazy.force init_logs >>= fun () -> f ())
   in
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-p2p"
     [ ( "p2p.peerset",
         List.map
           wrap
           [("empty", test_empty); ("ban", test_ban); ("gc", test_gc)] ) ]
+  |> Lwt_main.run

--- a/src/lib_p2p/test/test_p2p_io_scheduler.ml
+++ b/src/lib_p2p/test/test_p2p_io_scheduler.ml
@@ -254,7 +254,7 @@ let wrap n f =
           Format.kasprintf Stdlib.failwith "%a" pp_print_error error)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-p2p"
     [ ( "p2p.io-scheduler",
@@ -270,3 +270,4 @@ let () =
                 !port
                 !delay
                 !clients) ] ) ]
+  |> Lwt_main.run

--- a/src/lib_p2p/test/test_p2p_pool.ml
+++ b/src/lib_p2p/test/test_p2p_pool.ml
@@ -968,7 +968,7 @@ let main () =
   Arg.parse spec anon_fun usage_msg ;
   let ports = !port -- (!port + !clients - 1) in
   let points = List.map (fun port -> (!addr, port)) ports in
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-p2p"
     [ ( "p2p-connection-pool",
@@ -981,6 +981,7 @@ let main () =
               Overcrowded.run_mixed_versions points);
           wrap "no-common-network-protocol" (fun _ ->
               No_common_network.run points) ] ) ]
+  |> Lwt_main.run
 
 let () =
   Sys.catch_break true ;

--- a/src/lib_p2p/test/test_p2p_socket.ml
+++ b/src/lib_p2p/test/test_p2p_socket.ml
@@ -607,7 +607,7 @@ let main () =
   let anon_fun _num_peers = raise (Arg.Bad "No anonymous argument.") in
   let usage_msg = "Usage: %s.\nArguments are:" in
   Arg.parse spec anon_fun usage_msg ;
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-p2p"
     [ ( "p2p-connection.",
@@ -621,6 +621,7 @@ let main () =
           wrap "close-on-write" Close_on_write.run;
           wrap "garbled-data" Garbled_data.run;
           Crypto_test.wrap () ] ) ]
+  |> Lwt_main.run
 
 let () =
   Sys.catch_break true ;

--- a/src/lib_protocol_environment/test/test.ml
+++ b/src/lib_protocol_environment/test/test.ml
@@ -24,4 +24,7 @@
 (*****************************************************************************)
 
 let () =
-  Alcotest.run "tezos-shell-context" [("mem_context", Test_mem_context.tests)]
+  Alcotest_lwt.run
+    "tezos-shell-context"
+    [("mem_context", Test_mem_context.tests)]
+  |> Lwt_main.run

--- a/src/lib_requester/test/test_requester.ml
+++ b/src/lib_requester/test/test_requester.ml
@@ -639,10 +639,13 @@ let test_full_requester_shutdown _ () =
   Test_Requester.shutdown req
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     "tezos-requester"
     [ ( "all",
-        [ Alcotest.test_case "test create: simple" `Quick test_full_requester;
+        [ Alcotest_lwt.test_case_sync
+            "test create: simple"
+            `Quick
+            test_full_requester;
           Alcotest_lwt.test_case
             "test create: test known"
             `Quick
@@ -735,7 +738,7 @@ let () =
             "test notify: disk duplicate"
             `Quick
             test_full_requester_test_notify_disk_duplicate;
-          Alcotest.test_case
+          Alcotest_lwt.test_case_sync
             "test pending_requests"
             `Quick
             test_full_requester_test_pending_requests;
@@ -747,3 +750,4 @@ let () =
             "test shutdown"
             `Quick
             test_full_requester_shutdown ] ) ]
+  |> Lwt_main.run

--- a/src/lib_shell/test/test.ml
+++ b/src/lib_shell/test/test.ml
@@ -25,10 +25,11 @@
 (*****************************************************************************)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     "tezos-state"
     [ ("store", Test_store.tests);
       ("state", Test_state.tests);
       ("store checkpoint", Test_store_checkpoint.tests);
       ("state checkpoint", Test_state_checkpoint.tests);
       ("test protocol validator", Test_protocol_validator.tests) ]
+  |> Lwt_main.run

--- a/src/lib_shell/test/test_locator.ml
+++ b/src/lib_shell/test/test_locator.ml
@@ -389,4 +389,6 @@ let tests =
   try if Sys.argv.(1) = "--no-bench" then tests else tests @ bench
   with _ -> tests @ bench
 
-let () = Alcotest.run ~argv:[|""|] "tezos-shell" [("locator", tests)]
+let () =
+  Alcotest_lwt.run ~argv:[|""|] "tezos-shell" [("locator", tests)]
+  |> Lwt_main.run

--- a/src/lib_signer_backends/test/test_encrypted.ml
+++ b/src/lib_signer_backends/test/test_encrypted.ml
@@ -156,4 +156,6 @@ let tests =
   [ Alcotest_lwt.test_case "random_roundtrip" `Quick test_random;
     Alcotest_lwt.test_case "vectors_decrypt" `Quick test_vectors ]
 
-let () = Alcotest.run "tezos-signer-backends" [("encrypted", tests)]
+let () =
+  Alcotest_lwt.run "tezos-signer-backends" [("encrypted", tests)]
+  |> Lwt_main.run

--- a/src/lib_storage/test/test.ml
+++ b/src/lib_storage/test/test.ml
@@ -24,6 +24,7 @@
 (*****************************************************************************)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     "tezos-storage"
     [("context", Test_context.tests); ("raw_store", Test_raw_store.tests)]
+  |> Lwt_main.run

--- a/src/proto_006_PsCARTHA/lib_client/test/test_michelson_v1_macros.ml
+++ b/src/proto_006_PsCARTHA/lib_client/test/test_michelson_v1_macros.ml
@@ -1061,7 +1061,8 @@ let wrap (n, f) =
           Format.kasprintf Stdlib.failwith "%a" pp_print_error error)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-lib-client"
     [("micheline v1 macros", List.map wrap tests)]
+  |> Lwt_main.run

--- a/src/proto_006_PsCARTHA/lib_protocol/test/main.ml
+++ b/src/proto_006_PsCARTHA/lib_protocol/test/main.ml
@@ -24,7 +24,7 @@
 (*****************************************************************************)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     "protocol_006_PsCARTHA"
     [ ("transfer", Transfer.tests);
       ("origination", Origination.tests);
@@ -39,3 +39,4 @@ let () =
       ("combined", Combined_operations.tests);
       ("qty", Qty.tests);
       ("voting", Voting.tests) ]
+  |> Lwt_main.run

--- a/src/proto_alpha/lib_client/test/test_michelson_v1_macros.ml
+++ b/src/proto_alpha/lib_client/test/test_michelson_v1_macros.ml
@@ -1061,7 +1061,8 @@ let wrap (n, f) =
           Format.kasprintf Stdlib.failwith "%a" pp_print_error error)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     ~argv:[|""|]
     "tezos-lib-client"
     [("micheline v1 macros", List.map wrap tests)]
+  |> Lwt_main.run

--- a/src/proto_alpha/lib_protocol/test/main.ml
+++ b/src/proto_alpha/lib_protocol/test/main.ml
@@ -24,7 +24,7 @@
 (*****************************************************************************)
 
 let () =
-  Alcotest.run
+  Alcotest_lwt.run
     "protocol_alpha"
     [ ("transfer", Transfer.tests);
       ("origination", Origination.tests);
@@ -40,3 +40,4 @@ let () =
       ("qty", Qty.tests);
       ("voting", Voting.tests);
       ("interpretation", Interpretation.tests) ]
+  |> Lwt_main.run


### PR DESCRIPTION
This gets around a problem I was having with conflicting constraints on the `Result` compatibility package when trying to vendor `irmin-rpc`. It turned out to be faster to just switch to the new API than to try to find a happy set of versions of everything.

We may want to upstream this one.