### PR TITLE
bin_node: add an initial `storage` command

### DIFF
--- a/src/bin_node/main.ml
+++ b/src/bin_node/main.ml
@@ -76,7 +76,8 @@ let description =
     `P Node_config_command.Manpage.command_description;
     `P Node_upgrade_command.Manpage.command_description;
     `P Node_snapshot_command.Manpage.command_description;
-    `P Node_reconstruct_command.Manpage.command_description ]
+    `P Node_reconstruct_command.Manpage.command_description;
+    `P Node_storage_command.Manpage.command_description ]
 
 let man = description @ Node_run_command.Manpage.examples
 
@@ -94,7 +95,8 @@ let commands =
     Node_identity_command.cmd;
     Node_upgrade_command.cmd;
     Node_snapshot_command.cmd;
-    Node_reconstruct_command.cmd ]
+    Node_reconstruct_command.cmd;
+    Node_storage_command.cmd ]
 
 let () =
   Random.self_init () ;

--- a/src/bin_node/node_storage_command.ml
+++ b/src/bin_node/node_storage_command.ml
@@ -1,0 +1,157 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* Open Source License                                                       *)
+(* Copyright (c) 2020 Tarides <contact@tarides.com>                          *)
+(*                                                                           *)
+(* Permission is hereby granted, free of charge, to any person obtaining a   *)
+(* copy of this software and associated documentation files (the "Software"),*)
+(* to deal in the Software without restriction, including without limitation *)
+(* the rights to use, copy, modify, merge, publish, distribute, sublicense,  *)
+(* and/or sell copies of the Software, and to permit persons to whom the     *)
+(* Software is furnished to do so, subject to the following conditions:      *)
+(*                                                                           *)
+(* The above copyright notice and this permission notice shall be included   *)
+(* in all copies or substantial portions of the Software.                    *)
+(*                                                                           *)
+(* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR*)
+(* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  *)
+(* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL   *)
+(* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER*)
+(* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING   *)
+(* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER       *)
+(* DEALINGS IN THE SOFTWARE.                                                 *)
+(*                                                                           *)
+(*****************************************************************************)
+
+let term_name = "storage"
+
+module Term = struct
+  open Cmdliner
+
+  (* [Cmdliner] terms are not nestable, so we implement an ad-hoc mechanism for
+     delegating to one of several "subcommand"s by parsing a single positional
+     argument and then calling [Term.eval] again with the remaining
+     arguments. *)
+
+  type subcommand = {
+    name : string;
+    description : string;
+    term : (unit -> unit) Term.t;
+  }
+
+  let terms =
+    let open Context.Checks in
+    [ {
+        name = "check-self-contained";
+        description =
+          "Check that the upper layer of the store is self-contained.";
+        term = Pack.Check_self_contained.term;
+      };
+      {
+        name = "integrity-check-index";
+        description = "Search the store for integrity faults and corruption.";
+        term = Index.Integrity_check.term;
+      };
+      {
+        name = "stat-index";
+        description = "Print high-level statistics about the index store.";
+        term = Index.Stat.term;
+      };
+      {
+        name = "stat-pack";
+        description = "Print high-level statistics about the pack file.";
+        term = Pack.Stat.term;
+      } ]
+
+  let dispatch_subcommand = function
+    | None ->
+        `Help (`Auto, Some term_name)
+    | Some n -> (
+      match List.find_opt (fun {name; _} -> name = n) terms with
+      | None ->
+          let msg =
+            let pp_ul = Fmt.(list ~sep:cut (const string "- " ++ string)) in
+            terms
+            |> List.map (fun {name; _} -> name)
+            |> Fmt.str
+                 "@[<v 0>Unrecognized command: %s@,\
+                  @,\
+                  Available commands:@,\
+                  %a@,\
+                  @]"
+                 n
+                 pp_ul
+          in
+          `Error (false, msg)
+      | Some command -> (
+          let (binary_name, argv) =
+            (* Get remaining arguments for subcommand evaluation *)
+            ( Sys.argv.(0),
+              Array.init
+                (Array.length Sys.argv - 2)
+                (function 0 -> Sys.argv.(0) | i -> Sys.argv.(i + 2)) )
+          in
+          let noop_formatter =
+            Format.make_formatter (fun _ _ _ -> ()) (fun () -> ())
+          in
+          Term.eval
+            ~argv
+            ~err:noop_formatter (* Defaults refer to non-existent help *)
+            ~catch:false (* Will be caught by parent [Term.eval_choice] *)
+            ( command.term,
+              Term.info (binary_name ^ " " ^ term_name ^ " " ^ command.name) )
+          |> function
+          | `Ok f ->
+              `Ok (f ())
+          | `Help | `Version ->
+              (* Parent term evaluation intercepts [--help] and [--version] *)
+              assert false
+          | `Error _ -> (
+              (* We want to display the usage information for the selected
+                 subcommand, but [Cmdliner] will only do this at evaluation
+                 time *)
+              Term.eval
+                ~argv:[|""; "--help=plain"|]
+                ( command.term,
+                  Term.info (binary_name ^ " " ^ term_name ^ " " ^ command.name)
+                )
+              |> function `Help -> `Ok () | _ -> assert false ) ) )
+
+  let term =
+    let subcommand =
+      (* NOTE: [Cmdliner] doesn't have a wildcard argument or mechanism for
+         deferring the parsing of arguments, so this term must explicitly
+         support any options required by the subcommands *)
+      Arg.(value @@ pos_all string [] (info ~docv:"COMMAND" []))
+      |> Term.(app (const List.hd_opt))
+    in
+    Term.(ret (const dispatch_subcommand $ subcommand))
+end
+
+module Manpage = struct
+  let command_description =
+    "The $(b,storage) command provides tools for introspecting and debugging \
+     the storage layer."
+
+  let commands =
+    [ `S Cmdliner.Manpage.s_commands;
+      `P "The following subcommands are available:";
+      `Blocks
+        (List.map
+           (fun Term.{name; description; _} ->
+             `I (Printf.sprintf " $(b,%s)" name, description))
+           Term.terms);
+      `P
+        "$(b,WARNING): this API is experimental and may change in future \
+         versions." ]
+
+  let man = commands @ Node_shared_arg.Manpage.bugs
+
+  let info =
+    Cmdliner.Term.info
+      ~doc:"Query the storage layer (EXPERIMENTAL)"
+      ~man
+      term_name
+end
+
+let cmd = (Term.term, Manpage.info)

--- a/src/bin_node/node_storage_command.mli
+++ b/src/bin_node/node_storage_command.mli
@@ -1,0 +1,30 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* Open Source License                                                       *)
+(* Copyright (c) 2020 Tarides <contact@tarides.com>                          *)
+(*                                                                           *)
+(* Permission is hereby granted, free of charge, to any person obtaining a   *)
+(* copy of this software and associated documentation files (the "Software"),*)
+(* to deal in the Software without restriction, including without limitation *)
+(* the rights to use, copy, modify, merge, publish, distribute, sublicense,  *)
+(* and/or sell copies of the Software, and to permit persons to whom the     *)
+(* Software is furnished to do so, subject to the following conditions:      *)
+(*                                                                           *)
+(* The above copyright notice and this permission notice shall be included   *)
+(* in all copies or substantial portions of the Software.                    *)
+(*                                                                           *)
+(* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR*)
+(* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  *)
+(* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL   *)
+(* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER*)
+(* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING   *)
+(* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER       *)
+(* DEALINGS IN THE SOFTWARE.                                                 *)
+(*                                                                           *)
+(*****************************************************************************)
+
+val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+
+module Manpage : sig
+  val command_description : string
+end

--- a/src/lib_context/context.ml
+++ b/src/lib_context/context.ml
@@ -303,13 +303,28 @@ module Conf = struct
 end
 
 module Store =
-  Irmin_pack.Make_ext_layered (Conf) (Irmin.Metadata.None) (Contents)
+  Irmin_pack.Layered.Make_ext (Conf) (Irmin.Metadata.None) (Contents)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)
     (Node)
     (Commit)
 module P = Store.Private
+
+module Checks = struct
+  module Pack =
+    Irmin_pack.Checks.Make (Conf) (Irmin.Metadata.None) (Contents)
+      (Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Hash)
+      (Node)
+      (Commit)
+
+  module Index = struct
+    module I = Irmin_pack.Index.Make (Hash)
+    include I.Checks
+  end
+end
 
 type index = {
   path : string;

--- a/src/lib_context/context.mli
+++ b/src/lib_context/context.mli
@@ -294,6 +294,13 @@ val check_protocol_commit_consistency :
   parents_contexts:Context_hash.t list ->
   bool Lwt.t
 
+(** Offline integrity checking and statistics for contexts. *)
+module Checks : sig
+  module Pack : Irmin_pack.Checks.S
+
+  module Index : Index.Checks.S
+end
+
 (**/**)
 
 (** {b Warning} For testing purposes only *)


### PR DESCRIPTION
This adds a `tezos-node storage` command, with quite a few hacks necessary to get something "like" subcommands via Cmdliner. 

Even with these hacks, it's not perfect: this subcommand specification would need to re-state any optional arguments in order to prevent the top-level `Term.eval` from immediately failing. There are no such optional arguments at the moment, but something to be wary of in the future.